### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ GitHub 漫游指南- a Chinese ebook on how to build a good build on Github
 
 ***
 # 乱入
-####WWDC
+#### WWDC
 [集合了2010—2015年所有WWDC的视频字](http://asciiwwdc.com/)
 
 [查看GitHub代码的Chrome插件](https://github.com/buunguyen/octotree)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
